### PR TITLE
Filter column names in timelists.read

### DIFF
--- a/src/owlplanner/timelists.py
+++ b/src/owlplanner/timelists.py
@@ -54,7 +54,7 @@ def read(finput, inames, horizons, mylog):
     else:
         # Read all worksheets in memory but only process those with proper names.
         try:
-            dfDict = pd.read_excel(finput, sheet_name=None)
+            dfDict = pd.read_excel(finput, sheet_name=None, usecols=_timeHorizonItems)
         except Exception as e:
             raise Exception(f"Could not read file {finput}: {e}.") from e
         streamName = f"file '{finput}'"


### PR DESCRIPTION
This PR filters out un-used column names in the timelists sheets. That allows you to use any columns outside of the reserved ones as scratch area to do whatever calculations you want in excel.

Currently, if you put random mixed data (text + numbers) in a column, pandas will throw an exception.