### PR TITLE
Fixes to match Docker Hub name

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -16,11 +16,11 @@ application installed on your computer.
 
 Downloading the Docker image from the command line:
 ```
-docker pull owlplanner/owldocker
+docker pull owlplanner/owldocker.run
 ```
 Then the container can be started (and stopped) from the command line:
 ```
-docker run -p 8501:8501 --rm owlplanner/owldocker
+docker run -p 8501:8501 --rm owlplanner/owldocker.run
 ```
 
 Just point your browser to http://localhost:8501 to access the Owl user interface.


### PR DESCRIPTION
The existing commands throw a "repository does not exist" error when attempting to run the Docker image.  This corrects the commands to match the published Docker Hub image name.