### PR TITLE
RFC: Documentation and GitHub Pages restructure

### DIFF
--- a/.github/RFC-docs-restructure-placeholder.md
+++ b/.github/RFC-docs-restructure-placeholder.md
@@ -1,0 +1,9 @@
+# RFC: Documentation and GitHub Pages Restructure
+
+This file exists solely to enable a draft PR for discussion.
+
+Please see the draft PR description for the full proposal and
+discussion. No implementation is included here.
+
+If the RFC PR is closed without merging, this file will not be added to main and will effectively disappear from the project.
+


### PR DESCRIPTION
RFC - Request for Comment - I'm using this draft PR to open a discussion prior to making any changes.  When this discussion is complete, we can close this PR without merging, and a new PR can be used for the actual changes (if any).  A dummy file needed to be included so that GITHUB would open the PR.  Closing without merging ensures that this dummy file isn't added to the main branch.

I propose that we rename the `./docs` directory to `./paper` and reserve the `./docs` directory for a ghpages website.  [GH Pages](https://docs.github.com/en/pages) is a free static webhosting service offered by GITHUB for all github projects.  The folder `./docs` contains a static website that is displayed by github.

Further, I propose we create a new folder `./site` in the main directory.  This folder will contain the source code for the website, which can then be "published" to the `./docs` folder.  When the changes are committed and pushed, github will automatically update the project website using the content in the `./docs/` folder.

Finally, I propose that we use [Quarto](https://quarto.org/) to create/maintain the web site.  Quarto does LOTS more and integrates very nicely with python, but we can immediately use it to craft a [web site](https://quarto.org/docs/websites/). Websites created using Quarto are built using python and markdown.  Very easy to maintain!

As an example, here is a source github repository and it's corresponding ghpages:
* [REPO 2](https://github.com/vcu-ssg/ssg-atlantic-sturgeons) and [GH Page site 2](https://vcu-ssg.github.io/ssg-atlantic-sturgeons/website/about.html)
* [REPO](https://github.com/lowkeylabs/cmsc427-course-admin)  and [GH Page Site](https://lowkeylabs.github.io/cmsc427-course-admin/sp2025/)

The GHPages site is NOT intended to replace documentation for the OwlPlanner tool itself.  The embedded documentation does just fine - although new versions of the software need to be pushed when the documentation change.

The GHPages site can complement the software documentation by providing tutorials, examples, and best-practices that can be maintained separately from the software itself.  Fixes to the documentation, new tutorials, etc. can be committed to the site without having to push a new version of the software.

As a start, the current content of README.md could be moved to the index.html of the ghpage site, allowing README to focus more on installation and other repo-oriented particulars.  I propose this simple change (README -> index.qmd/html) as the first iteration of the ghpages site.  An expanded "Instructions for developers" page can also be added.

