### PR TITLE
Tightly integraded loguru.  Added global log with filters.

### DIFF
--- a/src/owlplanner/plan.py
+++ b/src/owlplanner/plan.py
@@ -370,7 +370,7 @@ class Plan:
         self.mylog = logger
 
     def setLogstreams(self, verbose, logstreams):
-        self.mylog = log.Logger(verbose, logstreams)
+        self.mylog = log.Logger(verbose, logstreams,stream_id=self._name)
         # self.mylog.vprint(f"Setting logstreams to {logstreams}.")
 
     def logger(self):

--- a/ui/Create_Case.py
+++ b/ui/Create_Case.py
@@ -6,6 +6,8 @@ import owlbridge as owb
 import tomlexamples as tomlex
 import case_progress as cp
 
+from loguru import logger
+
 
 ret = kz.titleBar(":material/person_add: Create Case", allCases=True)
 
@@ -30,6 +32,7 @@ elif ret == kz.loadCaseFile:
         st.markdown("#### :orange[Upload Your Own Case File]")
         file = st.file_uploader("Upload *case* parameter file...", key="_confile", type=["toml"])
         if file is not None:
+            logger.info(f"Loading case file: '{file.name}'")
             mystringio = StringIO(file.read().decode("utf-8"))
             if kz.createCaseFromFile(mystringio):
                 st.rerun()
@@ -39,6 +42,7 @@ elif ret == kz.loadCaseFile:
         case = st.selectbox("Examples available from GitHub", tomlex.cases, index=None,
                             placeholder="Select an example case")
         if case:
+            logger.info(f"Loading example: '{case}'")
             mystringio = tomlex.loadCaseExample(case)
             if kz.createCaseFromFile(mystringio):
                 kz.initCaseKey("tomlexcase", case)
@@ -155,3 +159,4 @@ Hit the `Create case` button once all parameters on this page are right."""
 
 # Show progress bar at bottom (always shown on Create Case page)
 cp.show_progress_bar()
+

--- a/ui/Logs2.py
+++ b/ui/Logs2.py
@@ -1,0 +1,88 @@
+import streamlit as st
+import sskeys as kz
+import io
+
+ret = kz.titleBar(":material/error: Logs2")
+
+# -------------------------------
+# Session state initialization
+# -------------------------------
+if "active_case_filter" not in st.session_state:
+    st.session_state.active_case_filter = None
+
+if "text_filter" not in st.session_state:
+    st.session_state.text_filter = ""
+
+# -------------------------------
+# Top controls
+# -------------------------------
+ctrl_cols = st.columns([3, 1])
+
+st.session_state.text_filter = ctrl_cols[0].text_input(
+    "Search logs – Enter string or select filter by case name.",
+    value=st.session_state.text_filter,
+    placeholder="Substring match (e.g. Case1)"
+)
+
+# ---- Clear log button (resets StringIO) ----
+if ctrl_cols[1].button(
+    "Clear log",
+    type="secondary",
+    use_container_width=True,
+):
+    strio = kz.getGlobalKey("loguruLogger")
+    if strio is not None:
+        strio.seek(0)
+        strio.truncate(0)
+
+# -------------------------------
+# Case name buttons
+# -------------------------------
+case_names = kz.onlyCaseNames()
+cols = st.columns(len(case_names) + 1)
+
+for i, name in enumerate(case_names):
+    active = (st.session_state.active_case_filter == name)
+
+    if cols[i].button(
+        name,
+        key=f"case_{name}",
+        type="secondary" if active else "primary",
+        disabled=active,                 # 👈 cannot be clicked again
+        use_container_width=True,
+    ):
+        st.session_state.active_case_filter = name
+        st.session_state.text_filter = ""  # 👈 reset text filter
+
+# -------------------------------
+# Clear filters button
+# -------------------------------
+if cols[-1].button(
+    "Clear filters",
+    type="secondary",
+    use_container_width=True,
+):
+    st.session_state.active_case_filter = None
+    st.session_state.text_filter = ""
+
+# -------------------------------
+# Apply filters to logs
+# -------------------------------
+strio = kz.getGlobalKey("loguruLogger")
+if strio is not None:
+    logmsg = strio.getvalue()
+    lines = logmsg.splitlines()
+
+    # Text filter
+    if st.session_state.text_filter:
+        lines = [
+            line for line in lines
+            if st.session_state.text_filter in line
+        ]
+
+    # Single case filter
+    if st.session_state.active_case_filter:
+        case = st.session_state.active_case_filter
+        lines = [line for line in lines if case in line]
+
+    st.code("\n".join(lines), language=None)

--- a/ui/main.py
+++ b/ui/main.py
@@ -1,5 +1,7 @@
 import streamlit as st
 import os
+from io import StringIO
+from loguru import logger
 
 import sskeys as kz
 
@@ -37,12 +39,22 @@ pages = {
         st.Page("Documentation.py", icon=":material/help:"),
         st.Page("Settings.py", icon=":material/settings:"),
         st.Page("Logs.py", icon=":material/error:"),
+        st.Page("Logs2.py", icon=":material/error:"),
         st.Page("About_Owl.py", icon=":material/info:"),
     ],
 }
 
 kz.initGlobalKey("menuLocation", "top")
 kz.initGlobalKey("position", "sticky")
+
+if kz.getGlobalKey("loguruLogger") is None:
+    loguruLogger = StringIO()
+    kz.initGlobalKey("loguruLogger", loguruLogger)
+    logger.remove()
+    fmt1 = "{time:YYYY-MM-DD HH:mm:ss} | {level:<8} | {module}:{line} | {message}"
+    logger.add(loguruLogger, format=fmt1, level="DEBUG")
+    logger.info("Global logging started.")
+
 
 pg = st.navigation(pages, position=kz.getGlobalKey("menuLocation"))
 


### PR DESCRIPTION
* Integrated loguru with streamlit,
* Added new Resource menu item: Log2.  The page displays all log messages across streamlit and cases. Page offers filters to select messages for any specific case, or global.
* Added new keyword argument to logger.init( stream_id=None ).  When a plan creates a local log, it adds it's name as a stream_id.  In the logger, if a stream ID exists, it includes it in the log message.
* Loguru messages live inside PRINT and VPRINT.  Loguru is amended to display the module:line of the call to VPRINT or PRINT and not the call to the loguru logger itself.