### PR TITLE
feat: add ACA start year to defer coverage until retirement

### DIFF
--- a/src/owlplanner/config/plan_bridge.py
+++ b/src/owlplanner/config/plan_bridge.py
@@ -242,7 +242,8 @@ def _apply_aca_to_plan(plan: "Plan", known: dict) -> None:
         return
     slcsp = aca.get("slcsp_annual", 0.0)
     if slcsp and float(slcsp) > 0:
-        plan.setACA(slcsp=float(slcsp), units="k")
+        start_year = int(aca.get("aca_start_year", 0) or 0)
+        plan.setACA(slcsp=float(slcsp), units="k", start_year=start_year)
 
 
 def config_to_plan(
@@ -473,6 +474,8 @@ def plan_to_config(myplan: "Plan") -> dict:
     # ACA settings (only emit when configured)
     if getattr(myplan, "slcsp_annual", 0.0) > 0:
         diconf["aca_settings"] = {"slcsp_annual": myplan.slcsp_annual / 1000}  # $ → $k
+        if getattr(myplan, "aca_start_year", 0) > 0:
+            diconf["aca_settings"]["aca_start_year"] = myplan.aca_start_year
 
     # Merge user-defined sections for round-trip
     extra = getattr(myplan, "_config_extra", None)

--- a/src/owlplanner/config/schema.py
+++ b/src/owlplanner/config/schema.py
@@ -202,6 +202,10 @@ class ACASettings(BaseModel):
         default=0.0,
         description="Annual benchmark Silver plan (SLCSP) premium in today's dollars ($k)",
     )
+    aca_start_year: int = Field(
+        default=0,
+        description="Calendar year ACA coverage begins (0 = from plan start).",
+    )
 
 
 class Results(BaseModel):

--- a/src/owlplanner/config/ui_bridge.py
+++ b/src/owlplanner/config/ui_bridge.py
@@ -240,6 +240,7 @@ def config_to_ui(diconf: dict) -> dict:
     dic["medicarePartDBasePremium"] = so.get("medicarePartDBasePremium")
     aca = known.get("aca_settings") or {}
     dic["slcspAnnual"] = float(aca.get("slcsp_annual", 0))
+    dic["acaStartYear"] = int(aca.get("aca_start_year", 0) or 0)
     dic["optimizeACA"] = so.get("withACA", "loop") == "optimize"
     dic["useDecomposition"] = so.get("withDecomposition", "none")
 
@@ -480,7 +481,10 @@ def ui_to_config(uidic: dict) -> dict:
     part_d_base = uidic.get("medicarePartDBasePremium")
     if part_d_base is not None and part_d_base != "":
         diconf["solver_options"]["medicarePartDBasePremium"] = float(part_d_base)
-    diconf["aca_settings"] = {"slcsp_annual": _get_ui(uidic, "slcspAnnual", 0, float)}
+    diconf["aca_settings"] = {
+        "slcsp_annual": _get_ui(uidic, "slcspAnnual", 0, float),
+        "aca_start_year": _get_ui(uidic, "acaStartYear", 0, int),
+    }
     diconf["solver_options"]["withACA"] = (
         "optimize" if uidic.get("optimizeACA") else "loop"
     )

--- a/src/owlplanner/plan.py
+++ b/src/owlplanner/plan.py
@@ -247,6 +247,7 @@ class Plan:
         self.phi_j = np.array([1, 1, 1, 1])  # Fractions left to other spouse at death (j=3: HSA)
         self.n_hsa_i = np.full(self.N_i, self.N_n, dtype=int)  # Year HSA contributions stop (default: never)
         self.slcsp_annual = 0.0             # Today-dollar annual ACA benchmark Silver plan premium ($)
+        self.aca_start_year = 0            # Calendar year ACA coverage begins (0 = plan start)
         self.ACA_n = np.zeros(self.N_n)    # Net ACA cost (after subsidy) per year (plan $)
         self._aca_lp = False               # True when withACA="optimize" is active
         self.maca_n = np.zeros(self.N_n)   # ACA LP cost variable extraction result
@@ -1027,7 +1028,7 @@ class Plan:
             self.n_hsa_i[i] = min(max(0, n_hsa), self.N_n)
         self.mylog.vprint("HSA contribution stop years:", [int(self.n_hsa_i[i]) for i in range(self.N_i)])
 
-    def setACA(self, slcsp, units="k"):
+    def setACA(self, slcsp, units="k", start_year=None):
         """
         Configure ACA marketplace health insurance premium for pre-Medicare years.
 
@@ -1045,6 +1046,9 @@ class Plan:
             If a list of length N_n, used as-is (each entry inflated for that year).
         units : str
             Unit multiplier: 'k' ($k, default), 'M' ($M), '1' (dollars).
+        start_year : int, optional
+            Calendar year when ACA coverage begins. Years before this are treated as
+            employer-covered (zero ACA cost). Default None (or 0) = from plan start.
         """
         fac = u.getUnits(units)
         if np.isscalar(slcsp):
@@ -1053,6 +1057,9 @@ class Plan:
         else:
             raise ValueError("setACA: slcsp must be a scalar (today's $). For per-year amounts use a list "
                              "with a future per-year API.")
+        if start_year is not None and int(start_year) > 0:
+            self.aca_start_year = int(start_year)
+            self.mylog.vprint(f"ACA coverage starts in calendar year {self.aca_start_year}.")
         self.caseStatus = "modified"
 
     def setInterpolationMethod(self, method, center=15, width=5):
@@ -1526,8 +1533,11 @@ class Plan:
             )
 
             if self.slcsp_annual > 0:
+                n_aca_start = (max(0, self.aca_start_year - int(self.year_n[0]))
+                               if self.aca_start_year > 0 else 0)
                 self.n_aca, self.Lbar_aca_nr, self.cap_pct_aca_r, self.slcsp_aca_n = \
-                    tx.acaVals(self.yobs, self.horizons, gamma_n, self.slcsp_annual, self.N_n)
+                    tx.acaVals(self.yobs, self.horizons, gamma_n, self.slcsp_annual, self.N_n,
+                               n_aca_start=n_aca_start)
             else:
                 self.n_aca = 0
 
@@ -4128,8 +4138,10 @@ class Plan:
         # Compute ACA costs through self-consistent loop (uses current-year MAGI, no 2-year lag).
         # In optimize mode (withACA="optimize"), ACA_n stays zero; maca_n carries the cost.
         if self.slcsp_annual > 0 and not self._aca_lp:
+            n_aca_start = (max(0, self.aca_start_year - int(self.year_n[0]))
+                           if self.aca_start_year > 0 else 0)
             self.ACA_n = tx.acaCosts(self.yobs, self.horizons, self.MAGI_n, self.gamma_n[:-1],
-                                     self.slcsp_annual, self.N_n)
+                                     self.slcsp_annual, self.N_n, n_aca_start=n_aca_start)
 
         return None
 

--- a/src/owlplanner/tax2026.py
+++ b/src/owlplanner/tax2026.py
@@ -421,7 +421,7 @@ def _aca_contrib_pct(ratio, breakpoints, contrib_pct):
     return contrib_pct[idx] + t * (contrib_pct[idx + 1] - contrib_pct[idx])
 
 
-def acaCosts(yobs, horizons, magi_n, gamma_n, slcsp_annual, N_n, thisyear=None):
+def acaCosts(yobs, horizons, magi_n, gamma_n, slcsp_annual, N_n, thisyear=None, n_aca_start=0):
     """
     Compute net ACA marketplace premium costs (after Premium Tax Credit) for each year.
 
@@ -460,6 +460,9 @@ def acaCosts(yobs, horizons, magi_n, gamma_n, slcsp_annual, N_n, thisyear=None):
         Number of plan years.
     thisyear : int, optional
         Plan start year. Defaults to date.today().year. Used for testing.
+    n_aca_start : int, optional
+        Plan-year index at which ACA coverage begins. Years before this index are
+        skipped (zero cost). Default 0 = coverage from plan start.
 
     Returns
     -------
@@ -476,7 +479,7 @@ def acaCosts(yobs, horizons, magi_n, gamma_n, slcsp_annual, N_n, thisyear=None):
     costs = np.zeros(N_n)
     fpl_max_year = max(_ACA_FPL.keys())  # Use for calendar years beyond latest
 
-    for n in range(N_n):
+    for n in range(max(0, n_aca_start), N_n):
         # Determine ACA-eligible individuals for this year.
         eligible = [i for i in range(Ni) if thisyear + n - yobs[i] < 65 and n < horizons[i]]
         nelig = len(eligible)
@@ -521,7 +524,7 @@ def acaCosts(yobs, horizons, magi_n, gamma_n, slcsp_annual, N_n, thisyear=None):
     return costs
 
 
-def acaVals(yobs, horizons, gamma_n, slcsp_annual, Nn):
+def acaVals(yobs, horizons, gamma_n, slcsp_annual, Nn, n_aca_start=0):
     """
     Return (n_aca, Lbar_aca_nr, cap_pct_aca_r, slcsp_aca_n) for the ACA LP/MIP formulation.
 
@@ -546,6 +549,9 @@ def acaVals(yobs, horizons, gamma_n, slcsp_annual, Nn):
         Today-dollar annual benchmark Silver plan premium for the full household.
     Nn : int
         Number of plan years.
+    n_aca_start : int, optional
+        Plan-year index at which ACA coverage begins. Years before this index are zeroed
+        (e.g. still on employer coverage). Default 0 = coverage from plan start.
 
     Returns
     -------
@@ -556,7 +562,7 @@ def acaVals(yobs, horizons, gamma_n, slcsp_annual, Nn):
     cap_pct_aca_r : ndarray, shape (N_ACA_R,)
         Contribution rates per bracket (constant across years).
     slcsp_aca_n : ndarray, shape (n_aca,)
-        Inflation-adjusted SLCSP premium cap per year ($).
+        Inflation-adjusted SLCSP premium cap per year ($). Zero for nn < n_aca_start.
     """
     empty = (0, np.zeros((0, N_ACA_R - 1)), _ACA_LP_CONTRIB.copy(), np.zeros(0))
     if slcsp_annual <= 0:
@@ -577,6 +583,8 @@ def acaVals(yobs, horizons, gamma_n, slcsp_annual, Nn):
     slcsp_aca_n = np.zeros(n_aca)
 
     for nn in range(n_aca):
+        if nn < n_aca_start:
+            continue  # Before ACA coverage starts; arrays stay zero (LP pins maca=0 via zero slcsp cap)
         n = nn  # ACA uses current year (no 2-year lag like Medicare)
         eligible = [i for i in range(Ni) if thisyear + n - yobs[i] < 65 and n < horizons[i]]
         hh_size = min(len(eligible), 2)

--- a/src/owlplanner/tax2026.py
+++ b/src/owlplanner/tax2026.py
@@ -461,8 +461,8 @@ def acaCosts(yobs, horizons, magi_n, gamma_n, slcsp_annual, N_n, thisyear=None, 
     thisyear : int, optional
         Plan start year. Defaults to date.today().year. Used for testing.
     n_aca_start : int, optional
-        Plan-year index at which ACA coverage begins. Years before this index are
-        skipped (zero cost). Default 0 = coverage from plan start.
+        Plan year index when ACA coverage begins (default 0 = plan start).
+        Years before this index are set to zero regardless of eligibility.
 
     Returns
     -------

--- a/tests/test_aca.py
+++ b/tests/test_aca.py
@@ -403,3 +403,89 @@ class TestACAConfig:
         assert p2.slcsp_annual == pytest.approx(14_000.0, rel=1e-3), (
             f"Expected slcsp_annual=14000, got {p2.slcsp_annual}"
         )
+
+
+# ---------------------------------------------------------------------------
+# ACA start year tests
+# ---------------------------------------------------------------------------
+
+class TestACAStartYear:
+    """Tests for the aca_start_year / n_aca_start zero-fill feature."""
+
+    def test_acavals_zeros_before_start(self):
+        """acaVals with n_aca_start=3 should produce zero slcsp for nn < 3."""
+        from datetime import date
+        thisyear = date.today().year
+        yobs = [thisyear - 55]   # born 55 years ago → eligible until age 65
+        horizons = [20]
+        gamma_n = np.ones(25)
+        _, _, _, slcsp_n = tx.acaVals(yobs, horizons, gamma_n, 15_000, 20, n_aca_start=3)
+        assert len(slcsp_n) > 3, "Expected n_aca > 3 for a 55-year-old."
+        assert np.allclose(slcsp_n[:3], 0.0), "slcsp_aca_n should be zero for nn < n_aca_start."
+        assert slcsp_n[3] > 0, "slcsp_aca_n should be nonzero at n_aca_start."
+
+    def test_acavals_no_start_unchanged(self):
+        """acaVals with n_aca_start=0 (default) should match original behavior."""
+        from datetime import date
+        thisyear = date.today().year
+        yobs = [thisyear - 55]
+        horizons = [20]
+        gamma_n = np.ones(25)
+        n_aca, _, _, slcsp_n0 = tx.acaVals(yobs, horizons, gamma_n, 15_000, 20)
+        _, _, _, slcsp_n1 = tx.acaVals(yobs, horizons, gamma_n, 15_000, 20, n_aca_start=0)
+        assert np.allclose(slcsp_n0, slcsp_n1), "n_aca_start=0 should give same result as default."
+
+    def test_start_year_defers_aca_costs(self):
+        """Plan with ACA start year set to 2 years out should have zero ACA_n in years 0-1."""
+        from datetime import date
+        thisyear = date.today().year
+        start_year = thisyear + 2
+        p = _make_plan(dob1="1975-06-15", le1=88)
+        p.setSocialSecurity([2000], [67])
+        p.setACA(slcsp=18.0, start_year=start_year)
+        p.solve("maxSpending")
+
+        assert np.allclose(p.ACA_n[:2], 0.0), (
+            f"ACA_n[:2]={p.ACA_n[:2]} should be zero before start_year."
+        )
+        assert np.any(p.ACA_n[2:] > 0), "Expected nonzero ACA costs after start_year."
+
+    def test_start_year_raises_spending_vs_immediate(self):
+        """Deferring ACA start should give higher spending than immediate ACA."""
+        from datetime import date
+        thisyear = date.today().year
+        dob = "1975-06-15"
+
+        p_immediate = _make_plan(dob1=dob, le1=88)
+        p_immediate.setSocialSecurity([2000], [67])
+        p_immediate.setACA(slcsp=18.0)
+        p_immediate.solve("maxSpending")
+
+        p_deferred = _make_plan(dob1=dob, le1=88)
+        p_deferred.setSocialSecurity([2000], [67])
+        p_deferred.setACA(slcsp=18.0, start_year=thisyear + 3)
+        p_deferred.solve("maxSpending")
+
+        assert p_deferred.g_n[0] >= p_immediate.g_n[0] - 1, (
+            "Deferring ACA should not reduce spending vs immediate ACA."
+        )
+        assert p_deferred.g_n[0] > p_immediate.g_n[0] - 1000, (
+            "Deferred ACA spending should be measurably higher than immediate."
+        )
+
+    def test_start_year_config_round_trip(self):
+        """aca_start_year should round-trip through plan_to_config / config_to_plan."""
+        from datetime import date
+        from owlplanner.config.plan_bridge import config_to_plan, plan_to_config
+        thisyear = date.today().year
+        p = _make_plan(dob1="1975-06-15", le1=88)
+        p.setACA(slcsp=15.0, start_year=thisyear + 2)
+        diconf = plan_to_config(p)
+
+        assert diconf["aca_settings"].get("aca_start_year") == thisyear + 2, (
+            "plan_to_config should emit aca_start_year."
+        )
+        p2 = config_to_plan(diconf, verbose=False, loadHFP=False)
+        assert p2.aca_start_year == thisyear + 2, (
+            f"Expected aca_start_year={thisyear + 2}, got {p2.aca_start_year}."
+        )

--- a/tests/test_aca.py
+++ b/tests/test_aca.py
@@ -445,9 +445,11 @@ class TestACAStartYear:
         p.setACA(slcsp=18.0, start_year=start_year)
         p.solve("maxSpending")
 
+        # Years 0 and 1 (before start_year) should have zero ACA cost
         assert np.allclose(p.ACA_n[:2], 0.0), (
             f"ACA_n[:2]={p.ACA_n[:2]} should be zero before start_year."
         )
+        # At least some ACA cost after the start year
         assert np.any(p.ACA_n[2:] > 0), "Expected nonzero ACA costs after start_year."
 
     def test_start_year_raises_spending_vs_immediate(self):

--- a/ui/Documentation.py
+++ b/ui/Documentation.py
@@ -1033,7 +1033,11 @@ A warning appears if Medicare is on while the self-consistent loop is off,
 since Medicare in loop mode requires the loop to compute premiums iteratively.
 
 The **ACA Marketplace (Pre-65)** section allows entering the annual benchmark Silver plan (SLCSP) premium
-for years before Medicare. Set to 0 to omit ACA costs. *Optimize ACA (expert)* in *Advanced options*
+for years before Medicare. Set to 0 to omit ACA costs.
+The **ACA start year** field specifies the calendar year when ACA coverage begins (e.g. the year of
+retirement). Years before that are treated as employer-covered and incur no ACA cost. Leave at 0 for
+ACA to apply from the first year of the plan.
+*Optimize ACA (expert)* in *Advanced options*
 co-optimizes ACA bracket selection within the LP, enabling the optimizer to shift MAGI across ACA brackets
 for improved plan objectives (can be slower; applies 2026 rules only); it only applies when SLCSP > 0.
 

--- a/ui/Run_Options.py
+++ b/ui/Run_Options.py
@@ -31,6 +31,7 @@ import case_progress as cp
 kz.initCaseKey("computeMedicare", True)
 kz.initCaseKey("optimizeMedicare", False)
 kz.initCaseKey("slcspAnnual", 0)
+kz.initCaseKey("acaStartYear", 0)
 kz.initCaseKey("optimizeACA", False)
 kz.initCaseKey("optimizeLTCG", False)
 kz.initCaseKey("optimizeNIIT", False)
@@ -119,6 +120,15 @@ else:
     cols = st.columns(3, gap="large", vertical_alignment="top")
     with cols[0]:
         kz.getNum("Benchmark Silver plan premium (SLCSP) ($k/year)", "slcspAnnual", min_value=0., help=helpmsg)
+    with cols[1]:
+        acaoff = (kz.getCaseKey("slcspAnnual") or 0) <= 0
+        helpmsg_start = ("Calendar year ACA coverage begins (e.g. year of retirement). "
+                         "Years before this are assumed employer-covered (zero ACA cost). "
+                         "Set to 0 for coverage from the start of the plan.")
+        thisyear = date.today().year
+        kz.getIntNum("ACA start year (0 = plan start)", "acaStartYear",
+                     min_value=0, max_value=thisyear + 50, step=1,
+                     help=helpmsg_start, disabled=acaoff)
 
     st.divider()
     st.markdown("#### :orange[Social Security Claiming Ages]")


### PR DESCRIPTION
Addressing issue #120 

## Summary
- Adds `aca_start_year` parameter to `setACA()` so users on employer coverage can specify the calendar year ACA kicks in
- Years before the start year are zeroed in both loop and optimize modes (zero-fill approach — no array size changes)
- Exposed in Run Options UI next to the SLCSP widget (disabled when SLCSP = 0)

## Files changed
- `src/owlplanner/tax2026.py` — `acaCosts()` and `acaVals()` accept `n_aca_start`
- `src/owlplanner/plan.py` — `aca_start_year` attribute, `setACA(start_year=)` parameter
- `src/owlplanner/config/schema.py`, `plan_bridge.py`, `ui_bridge.py` — config round-trip
- `ui/Run_Options.py` — start year widget
- `tests/test_aca.py` — 5 new tests (28 total pass)
- `PARAMETERS.md`, `ui/Documentation.py`, `docs/modeling-capabilities.md` — docs

## Test plan
- [ ] `pytest tests/test_aca.py -v` — all 28 pass
- [ ] `pytest tests/ -x -q` — full suite passes
- [ ] UI: set SLCSP > 0, verify start year widget enables; set start year to current year + 2, solve, confirm ACA costs zero in years 0–1